### PR TITLE
Change color for placeholder from #fff to #808080.

### DIFF
--- a/static/styles.css
+++ b/static/styles.css
@@ -63,7 +63,7 @@
 }
 
 ::placeholder {
-  color: #fff;
+  color: #808080;
   opacity: 0.7; 
 }
 


### PR DESCRIPTION
![Screenshot 2023-08-22 213840](https://github.com/Heinrich-XIAO/Tweetor/assets/67009773/d50c5655-089c-4369-bea9-bdfac55a116b)

You may change your placeholder's text color to any other than #fff or #000.